### PR TITLE
Make the paths more relative

### DIFF
--- a/gswitch.sh
+++ b/gswitch.sh
@@ -1,8 +1,7 @@
 #!/bin/bash -x
 
 # First shot at gst-switch control
-
-PATH=~/src/gst-switch/tools:$PATH
+PATH="`pwd`/../gst-switch/tools:$PATH"
 
 ./dvs-mon.py -c gswitch.py 
 


### PR DESCRIPTION
If gst-switch and dvsmon are sibling folders, we can be nice and just fill in the pipe nicely for the user, instead of relying on a particular home directory layout.
